### PR TITLE
Test suite configuration enhancements (conn auth) and QueueManager tests, plus minor changes

### DIFF
--- a/code/tests/config.py
+++ b/code/tests/config.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import utils
 
 
 class PATHS:
@@ -14,13 +15,51 @@ class MQ:
         HOST = os.environ.get('PYMQI_TEST_QM_HOST', '127.0.0.1')
         PORT = os.environ.get('PYMQI_TEST_QM_PORT', '31414')
         CHANNEL = os.environ.get('PYMQI_TEST_QM_CHANNEL', 'SVRCONN.1')
+        TRANSPORT = os.environ.get('PYMQI_TEST_QM_TRANSPORT', 'TCP')
         USER = os.environ.get('PYMQI_TEST_QM_USER', 'myuser')
         PASSWORD = os.environ.get('PYMQI_TEST_QM_PASSWORD', 'mypassword')
 
+        MIN_COMMAND_LEVEL = os.environ.get(
+            'PYMQI_TEST_QM_MIN_COMMAND_LEVEL', '800')
+
+        class CONN_AUTH:
+            # user/password connection authentication is a MQ >= 8.0 feature
+            SUPPORTED = os.environ.get('PYMQI_TEST_QM_CONN_AUTH_SUPPORTED',
+                                       '1')
+            # Set to OPTIONAL or REQUIRED
+            # OPTIONAL: If a user ID and password are provided by a client
+            # application then they must be a valid pair. It is not mandatory
+            # to provide user + password, though.
+            # REQUIRED: A valid user ID and password are mandatory.
+            USE_PW = os.environ.get(
+                'PYMQI_TEST_QM_CONN_AUTH_USE_PW', 'OPTIONAL')
+
+            # Delay time in seconds for API call returns in case of auth
+            # failures (some DoS-countermeasure). For testing purposes we
+            # usually want this as fast as possible. This value gets used in
+            # create_mq_objects.py for the creation of the queue manager conn
+            # auth.
+            FAIL_DELAY = os.environ.get(
+                'PYMQI_TEST_QM_CONN_AUTH_FAIL_DELAY', '0')
+            
     # Queue naming setup
     class QUEUE:
         PREFIX = os.environ.get('PYMQI_TEST_QUEUE_PREFIX', '')
         QUEUE_NAMES = {
             'TestRFH2PutGet': PREFIX + 'TEST.PYMQI.RFH2PUTGET',
+            'TestQueueManager': PREFIX + 'TEST.PYMQI.QUEUEMANAGER',
             }
 
+    # convenience attribute derived from above settings, may be used for tests
+    # that mandate the MQSERVER environment variable
+    # E.g. MQSERVER="SVRCONN.1/TCP/mq.example.org(1777)"
+    MQSERVER = '%(channel)s/%(transport)s/%(host)s(%(port)s)' % {
+        'channel': QM.CHANNEL,
+        'transport': QM.TRANSPORT,
+        'host': QM.HOST,
+        'port': QM.PORT,
+        }
+
+
+if __name__ == '__main__':
+    utils.print_config(PATHS, MQ)

--- a/code/tests/create_mq_objects.py
+++ b/code/tests/create_mq_objects.py
@@ -12,15 +12,73 @@ import time
 import config
 
 
-mqsc_script = """
+LINE = "-" * 80 + "\n"
+
+
+# channel and tcp listener creation commands
+mqsc_script_channel_listener = """
 DEFINE CHL(%(channel)s) CHLTYPE(SVRCONN)
 DEFINE LISTENER(TCP.LISTENER.1) TRPTYPE(TCP) PORT(%(port)s) CONTROL(QMGR) REPLACE
 START LISTENER(TCP.LISTENER.1)
 """ % {
     'channel': config.MQ.QM.CHANNEL,
     'port': config.MQ.QM.PORT,
-    } + '\n'.join([ "DEFINE QL(%s) REPLACE" % qname 
+    } + '\n'.join([ "DEFINE QL(%s) REPLACE" % qname
                     for qname in config.MQ.QUEUE.QUEUE_NAMES.values() ])
+
+
+# user/password connection authentication setup (MQ>=8.0 only) 
+# CHK*(OPTIONAL): If a user ID and password are provided by a client
+# application then they must be a valid pair. It is not mandatory to provide
+# user + password, though.
+# This setting allows for testing against both MQ>=8.0 servers as well as older
+# MQ versions with same test codebase.
+mqsc_script_conn_auth_use_pw = """
+ALTER QMGR CONNAUTH(USE.PW)
+DEFINE AUTHINFO(USE.PW) AUTHTYPE(IDPWOS) FAILDLAY(%(faildlay)s) CHCKLOCL(OPTIONAL) CHCKCLNT(%(chckclnt)s)
+REFRESH SECURITY TYPE(CONNAUTH)
+""" % {
+    'chckclnt': config.MQ.QM.CONN_AUTH.USE_PW,
+    'faildlay': config.MQ.QM.CONN_AUTH.FAIL_DELAY,
+    }
+
+
+mqsc_script_no_conn_auth = """
+ALTER QMGR CONNAUTH(' ')
+REFRESH SECURITY TYPE(CONNAUTH)
+"""
+
+
+# Disable channel auth records feature.
+# WARNING: Admin client connections will now be accepted per default - use for
+# testing purposes only!
+mqsc_script_channel_auth = """
+ALTER QMGR CHLAUTH(DISABLED)
+"""
+
+
+def run_mqsc(mqsc_script, errormsg="MQSC commands not successful",
+             verbose=True):
+    """Helper function to run MQSC commands.
+
+    Returns a (returncode, stdout, stderr)-tuple of the command script.
+    """
+    if verbose:
+        print "runmqsc:"
+        print mqsc_script.replace('\n', '\n    ')
+    runmqsc_proc = subprocess.Popen(
+        ["runmqsc", config.MQ.QM.NAME], stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    runmqsc_output, runmqsc_error = runmqsc_proc.communicate(mqsc_script)
+    print LINE
+    print runmqsc_output
+    print LINE
+    if runmqsc_proc.returncode not in (0, 10):
+        print errormsg
+        print LINE
+        print runmqsc_error
+        print LINE
+    return runmqsc_proc.returncode, runmqsc_output, runmqsc_error
 
 
 print "Creating all MQ Objects required to run the test.\n"
@@ -78,18 +136,29 @@ else:
 
 time.sleep(2)
 
-print "Creating MQ Objects."
-runmqsc_proc = subprocess.Popen(["runmqsc", config.MQ.QM.NAME],
-                                stdout=subprocess.PIPE, stdin=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-runmqsc_output, runmqsc_error = runmqsc_proc.communicate(mqsc_script)
-print "-" * 80 + "\n"
-print runmqsc_output
-print "-" * 80 + "\n"
-if runmqsc_proc.returncode not in (0, 10):
-    print "Creation of MQ Objects not successful."
-    print "-" * 80 + "\n"
-    print runmqsc_error
-    print "-" * 80 + "\n"
+print "Creating MQ channel and listener Objects."
+run_mqsc(mqsc_script_channel_listener,
+         errormsg="MQ channel and listener objects creation not successful.")
+
+if config.MQ.QM.CONN_AUTH.SUPPORTED == '1':
+    print "Setting up MQ queue manager user/password connection authentication."
+    run_mqsc(mqsc_script_conn_auth_use_pw,
+         errormsg="MQ queue manager connection authentication setup not "
+         "successful.")
+else:
+    if int(config.MQ.QM.MIN_COMMAND_LEVEL) >= 800:
+        print "Switching off MQ queue manager connection authentication."
+        run_mqsc(mqsc_script_no_conn_auth,
+            errormsg="MQ queue manager connection authentication setup not "
+            "successful.")
+    else:
+        print "Connection authentication not applicable for pre-8.0 MQ."
+        
+    
+print "Disabling MQ queue manager channel authentication records feature."
+run_mqsc(mqsc_script_channel_auth,
+         errormsg="Disabling MQ queue manager channel authentication records "
+         "not successful.")
+
 
 print "MQ Environment Created.  Ready for tests.\n"

--- a/code/tests/test_queue_manager.py
+++ b/code/tests/test_queue_manager.py
@@ -3,9 +3,9 @@
 
 # stdlib
 import sys
+import os
+import unittest
 from uuid import uuid4
-
-sys.path.insert(0, "..")
 
 # nose
 from nose.tools import eq_
@@ -13,40 +13,186 @@ from nose.tools import eq_
 # testfixtures
 from testfixtures import Replacer
 
+# test env, configuration & utilities
+import env
+import config
+import utils
+
 # PyMQI
 import pymqi
+import pymqi.CMQC
 
+    
+class TestQueueManager(unittest.TestCase):
+    
+    qm_name = config.MQ.QM.NAME
+    channel = config.MQ.QM.CHANNEL
+    host = config.MQ.QM.HOST
+    port = config.MQ.QM.PORT
+    conn_info = "%s(%s)" % (host, port)
 
-def test_is_connected():
-    """ Makes sure the QueueManager's 'is_connected' property works as expected.
-    """
-    with Replacer() as r:
-        queue_manager = uuid4().hex
-        channel = uuid4().hex
-        host = uuid4().hex
-        port = "1431"
-        conn_info = "%s(%s)" % (host, port)
+    queue_name = config.MQ.QUEUE.QUEUE_NAMES['TestQueueManager']
 
-        for expected in(True, False):
+    user = config.MQ.QM.USER
+    password = config.MQ.QM.PASSWORD
+    
+    def test_init_none(self):
+        qmgr = pymqi.QueueManager(None)
+        self.assertFalse(qmgr.is_connected)
 
-            def _connectTCPClient(*ignored_args, **ignored_kwargs):
-                pass
+    # __init__ with a name calls connect:
+    # As the connect method provides no way to supply user & password, this
+    # cannot work if the queue manager requires it
+    @unittest.skipIf(
+        config.MQ.QM.CONN_AUTH.SUPPORTED and
+        config.MQ.QM.CONN_AUTH.USE_PW == 'REQUIRED',
+        'Test not viable for user/password-requiring queue manager')
+    @utils.with_env_complement('MQSERVER', config.MQ.MQSERVER)
+    def test_init_name(self):
+        # connecting with queue manager name needs MQSERVER set properly
+        qmgr = pymqi.QueueManager(self.qm_name)
+        self.assertTrue(qmgr.is_connected)
+        qmgr.disconnect()
 
-            def _getattr(self, name):
-                if expected:
-                    class _DummyMethod(object):
-                        pass
-                    # The mere fact of not raising an exception will suffice
-                    # for QueueManager._is_connected to understand it as an
-                    # all's OK condition.
-                    return _DummyMethod
-                else:
-                    raise Exception()
+    # As the connect method provides no way to supply user & password, this
+    # cannot work if the queue manager requires it
+    @unittest.skipIf(
+        config.MQ.QM.CONN_AUTH.SUPPORTED and
+        config.MQ.QM.CONN_AUTH.USE_PW == 'REQUIRED',
+        'Test not viable for user/password-requiring queue manager')
+    @utils.with_env_complement('MQSERVER', config.MQ.MQSERVER)
+    def test_connect(self):
+        # connecting with queue manager name needs MQSERVER set properly
+        print os.environ['MQSERVER']
+        qmgr = pymqi.QueueManager(None)
+        self.assertFalse(qmgr.is_connected)
+        qmgr.connect(self.qm_name)
+        self.assertTrue(qmgr.is_connected)
+        qmgr.disconnect()
+        
+    def test_connect_tcp_client(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=self.user,
+            password=self.password)
+        self.assertTrue(qmgr.is_connected)
+        qmgr.disconnect()
 
-            r.replace('pymqi.QueueManager.connectTCPClient', _connectTCPClient)
-            r.replace('pymqi.PCFExecute.__getattr__', _getattr)
+    # This test overlaps with
+    # test_mq80.test_successful_connect_without_optional_credentials,
+    # but hey, why not
+    @unittest.skipIf(
+        config.MQ.QM.CONN_AUTH.SUPPORTED and
+        config.MQ.QM.CONN_AUTH.USE_PW == 'REQUIRED',
+        'Test not viable with a user/password-requiring queue manager')
+    def test_connect_tcp_client_no_credentials(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=None,
+            password=None)
+        self.assertTrue(qmgr.is_connected)
+        qmgr.disconnect()
 
-            qmgr = pymqi.QueueManager(None)
-            qmgr.connectTCPClient(queue_manager, pymqi.cd(), channel, conn_info)
+    def test_disconnect(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=self.user,
+            password=self.password)
+        self.assertTrue(qmgr.is_connected)
+        qmgr.disconnect()
+        self.assertFalse(qmgr.is_connected)
 
-            eq_(qmgr.is_connected, expected)
+    def test_get_handle_unconnected(self):
+        qmgr = pymqi.QueueManager(None)
+        self.assertRaises(pymqi.PYIFError, qmgr.get_handle)
+
+    def test_get_handle_connected(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=self.user,
+            password=self.password)
+        handle = qmgr.get_handle()
+        # assertIsInstance is available >= Python2.7
+        self.assertTrue(isinstance(handle, int))
+        
+    @unittest.skip('Not implemented yet')
+    def test_begin(self):
+        pass
+
+    @unittest.skip('Not implemented yet')
+    def test_commit(self):
+        pass
+
+    @unittest.skip('Not implemented yet')
+    def test_backout(self):
+        pass
+
+    def test_put1(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=self.user,
+            password=self.password)
+        input_msg = 'Hello world!'
+        qmgr.put1(self.queue_name, input_msg)
+        # now get the message from the queue
+        queue = pymqi.Queue(qmgr, self.queue_name)
+        result_msg = queue.get()
+        self.assertEqual(input_msg, result_msg)
+
+    def test_inquire(self):
+        qmgr = pymqi.QueueManager(None)
+        qmgr.connect_tcp_client(
+            self.qm_name, pymqi.cd(), self.channel, self.conn_info, user=self.user,
+            password=self.password)
+        attribute = pymqi.CMQC.MQCA_Q_MGR_NAME
+        expected_value = self.qm_name
+        attribute_value = qmgr.inquire(attribute)
+        self.assertEqual(len(attribute_value), pymqi.CMQC.MQ_Q_MGR_NAME_LENGTH)  
+        self.assertEqual(attribute_value.strip(), expected_value)
+        
+    def test_is_connected(self):
+        """Makes sure the QueueManager's 'is_connected' property works as
+        expected.
+        """
+        # uses a mock so no real connection to a queue manager will be
+        # established - the parameters below are basically moot
+        with Replacer() as r:
+            queue_manager = uuid4().hex
+            channel = uuid4().hex
+            host = uuid4().hex
+            port = "1431"
+            conn_info = "%s(%s)" % (host, port)
+            user = "myuser"
+            password = "mypass"
+
+            for expected in(True, False):
+
+                def _connect_tcp_client(*ignored_args, **ignored_kwargs):
+                    pass
+
+                def _getattr(self, name):
+                    if expected:
+                        class _DummyMethod(object):
+                            pass
+                        # The mere fact of not raising an exception will suffice
+                        # for QueueManager._is_connected to understand it as an
+                        # all's OK condition.
+                        return _DummyMethod
+                    else:
+                        raise Exception()
+
+                r.replace('pymqi.QueueManager.connect_tcp_client',
+                          _connect_tcp_client)
+                r.replace('pymqi.PCFExecute.__getattr__', _getattr)
+
+                qmgr = pymqi.QueueManager(None)
+                qmgr.connect_tcp_client(
+                    queue_manager, pymqi.cd(), channel, conn_info, user,
+                    password)
+
+                eq_(qmgr.is_connected, expected)
+        
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/code/tests/test_rfh2_put_get.py
+++ b/code/tests/test_rfh2_put_get.py
@@ -45,8 +45,8 @@ class TestRFH2PutGet(unittest.TestCase):
         else:
             self.qmgr = pymqi.QueueManager(None)
             self.qmgr.connect_tcp_client(
-                queue_manager, pymqi.cd(), channel, conn_info, user=None,
-                password=None)
+                queue_manager, pymqi.cd(), channel, conn_info,
+                user=config.MQ.QM.USER, password=config.MQ.QM.PASSWORD)
         self.put_queue = pymqi.Queue(self.qmgr, queue_name)
         self.get_queue = pymqi.Queue(self.qmgr, queue_name)
         self.clear_queue(self.get_queue)

--- a/code/tests/utils.py
+++ b/code/tests/utils.py
@@ -1,0 +1,69 @@
+# Test helpers and utilities
+
+import sys
+import os
+import inspect
+import functools # >= Python 2.5
+
+
+def with_env_complement(env_var_name, envvar_value):
+    """Decorate test with environment additions.
+
+    Use for tests with mandatory environment variable requirements. If env
+    variable env_var_name is not set before test invocation, add it to the
+    environment with a value of envvar_value, run the test and remove
+    env_var_name again.
+    Runs the test without environment changes if env_var_name is set.
+    """
+    # The actual decorator that will accept the test function argument and wrap
+    # it with the optional env additions
+    def decorate(test_func):
+        @functools.wraps(test_func)
+        def _env_complemented(*args, **kwargs):
+            if not os.environ.has_key(env_var_name):
+                # enhance environment if env variable is not set
+                os.environ[env_var_name] = envvar_value
+                try:
+                    return test_func(*args, **kwargs)
+                finally:
+                    del os.environ[env_var_name]
+            else:
+                # run test as is, without changes to the environment
+                return test_func(*args, **kwargs)
+        return _env_complemented
+    return decorate
+
+
+# a helper to access the config class attributes
+def _visit(cls, prefix=()):
+    """Recursively traverse non-special cls attributes and yield
+    (qualified-name, value)-tuples. Generator function.
+
+    A "qualified" name is a (prefix, outer-cls, [inner-cls,] attr-name)-tuple.
+    Args:
+        cls: The (config) class to traverse for attribute lookup.
+        prefix: Optional prefix tuple.
+    """
+    for attr_name, attr_val in cls.__dict__.items():
+        if not attr_name.startswith('__'):
+            # ignore names that appear "special"
+            if inspect.isclass(attr_val):
+                # recursively
+                for visited in _visit(
+                        attr_val, prefix=prefix + (cls.__name__,)):
+                    yield visited
+            else:
+                yield (prefix + (cls.__name__, attr_name), attr_val)
+
+
+def print_config(*cfg_classes):
+    """Print configuration set in configuration classes cfg_classes.
+    """
+    print
+    print "Active configuration:"
+    for cls in cfg_classes:
+        for q_attr_name, attr_val in sorted(_visit(cls, prefix=('config',))):
+            print ("  %s: %s" % ('.'.join(q_attr_name), attr_val)).encode(
+                sys.stdout.encoding, 'replace')
+
+


### PR DESCRIPTION
This adds
- more elaborate configuration respected by both the tests and the create_mq_objects.py scripts; in my testing the tests can now be run successfully against both MQ 8 and MQ 7 queue manager installations with config changes only
- a utils module for some helpers used for some of the new test_queue_manager test methods
- test_mq8 module now works with different conn auth settings, and also if run against a MQ 7 queue manager (provided that an appropriate config gets chosen)

Note that create_mq_objects now switches off channel auth for the created test queue manager; I found that I had to do this manually otherwise.

Also, the fail delay feature for unsuccessful connections are now defaulted to 0.

Sorry that I haven't been able to provide a more minimal PR, again, but in the course of figuring out
the MQ settings that influence things I had to put changes at various places.

Looking forward to feedback and I can rework this, if necessary.

Best,
Holger
