### PR TITLE
Update __init__.py

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -1018,7 +1018,11 @@ class SCO(MQOpts):
             _mqcsco_version = CMQC.MQSCO_VERSION_4
 
         elif '7.0' in pymqe.__mqlevels__:
-            _mqcsco_version = CMQC.MQSCO_VERSION_3
+         
+            if CMQC.MQSCO_CURRENT_VERSION:
+                _mqcsco_version = CMQC.MQSCO_CURRENT_VERSION
+            else:
+                _mqcsco_version = CMQC.MQSCO_VERSION_3
 
         elif '6.0' in pymqe.__mqlevels__:
             _mqcsco_version = CMQC.MQSCO_VERSION_2
@@ -1041,7 +1045,7 @@ class SCO(MQOpts):
             opts += [['KeyResetCount', py23long(0), MQLONG_TYPE],
                      ['FipsRequired', py23long(0), MQLONG_TYPE]]
 
-        if "7.0" in pymqe.__mqlevels__:
+        if "7.0" in pymqe.__mqlevels__ and CMQC.MQSCO_CURRENT_VERSION > 2::
             opts += [['EncryptionPolicySuiteB', [0, 0, 0, 0], '4' + MQLONG_TYPE]]
 
         if "7.1" in pymqe.__mqlevels__:


### PR DESCRIPTION
Hello,
When I use pymqi, my program has some errors：
```python

Fail to connect to Queue, error: Traceback (most recent call last):
  File "/home/xdracct/XdrWorker/core/xdr_queue.py", line 148, in connect
    self._qmgr.connect_with_options(self._qm_name, opts=pymqi.CMQC.MQCNO_HANDLE_SHARE_NO_BLOCK, cd=cd)
  File "/home/xdracct/lib64/python3.6/site-packages/pymqi/__init__.py", line 1427, in connect_with_options
    if 'sco' in kw:
pymqe.error: MQSCO wrong size. Given: 560, expected 544

```
My pymqi ver: 1.8.1 (obtained via pip)
Python ver： 3.6.3
IMQ very： 7.0.1-13


After that, I solved this problem and found that 
this problem is caused by the CMQC.MQSCO_CURRENT_VERSION of this IMQ (7.0.1-13) 

```python
>>> import pymqi
>>> from pymqi import CMQC
>>> print("{}".format(CMQC.MQSCO_CURRENT_VERSION))
2
```
So there is no EncryptionPolicySuiteB attribute in this IMQ's MQSCO.