### PR TITLE
Use setuptools instead of bare distutils, fix building wheels

### DIFF
--- a/code/setup.py
+++ b/code/setup.py
@@ -7,7 +7,11 @@
 # stdlib
 import os
 import sys
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 from distutils.core import Extension
 from distutils import spawn
 from struct import calcsize

--- a/code/setup.py
+++ b/code/setup.py
@@ -7,7 +7,8 @@
 # stdlib
 import os
 import sys
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 from distutils import spawn
 from struct import calcsize
 


### PR DESCRIPTION
Hello,

In my environment, I need to build wheels for packages I use.

Since version 1.8.0 of pymqi, when I try to build wheels, I have the following error : "error: invalid command 'bdist_wheel'"

I noticed that the change https://github.com/dsuch/pymqi/commit/64264f6f5b11607713d33d37ef29591cae31c42e#diff-c7033a29db046a8e50421d24950c5773 broke the wheel building.

The change I made restore the usage of setuptools instead of distutils for setup function, it restores the wheel building feature (when wheel is installed).

Can you integrate this change ? Do you have a better solution ?