### PR TITLE
MQINQMP and MQSETMP modified for support non string properties

### DIFF
--- a/code/examples/message_property_set.py
+++ b/code/examples/message_property_set.py
@@ -1,0 +1,48 @@
+# See discussion and more examples at http://packages.python.org/pymqi/examples.html
+# or in doc/sphinx/examples.rst in the source distribution.
+
+import logging
+
+import pymqi
+
+logging.basicConfig(level=logging.INFO)
+
+queue_manager = "QM01"
+channel = "SVRCONN.1"
+host = "192.168.1.135"
+port = "1434"
+queue_name = "TEST.1"
+message = "Hello from Python!"
+property_name = "Propertie_1"
+conn_info = "%s(%s)" % (host, port)
+
+qmgr = pymqi.connect(queue_manager, channel, conn_info)
+
+put_msg_h = pymqi.MessageHandle(qmgr)
+put_msg_h.properties.set(property_name, message) #default type is CMQC.MQTYPE_STRING
+
+pmo = pymqi.PMO(Version=pymqi.CMQC.MQPMO_VERSION_3) #PMO v3 is minimal for using propeties
+pmo.OriginalMsgHandle = put_msg_h.msg_handle
+
+put_md = pymqi.MD(Version=pymqi.CMQC.MQMD_CURRENT_VERSION)
+
+put_queue = pymqi.Queue(qmgr, queue_name)
+put_queue.put(b'', put_md, pmo)
+
+#getting message with propertie
+get_msg_h = pymqi.MessageHandle(qmgr)
+
+gmo = pymqi.GMO(Version=pymqi.CMQC.MQGMO_CURRENT_VERSION)
+gmo.Options = pymqi.CMQC.MQGMO_PROPERTIES_IN_HANDLE
+gmo.MsgHandle = get_msg_h.msg_handle
+
+get_md = pymqi.MD()
+get_queue = pymqi.Queue(qmgr, queue_name)
+message_body = get_queue.get(None, get_md, gmo)
+
+property_value = get_msg_h.properties.get(property_name)
+logging.info("Message received. Propertie name: `%s`, propertie value: `%s`" % (property_name, property_value))
+
+put_queue.close()
+get_queue.close()
+qmgr.disconnect()

--- a/code/tests/test_message_property.py
+++ b/code/tests/test_message_property.py
@@ -11,11 +11,22 @@ import pymqi
 class TestMP(unittest.TestCase):
     def setUp(self):
 
-        self.msg_prop_name = utils.py3str2bytes("test_name")
-        self.msg_prop_value = utils.py3str2bytes("test_valuetest_valuetest_valuetest_valuetest_value")
+        self.msg_prop_name = b"test_name"
+
+        self.msg_prop_value_str = "test_valuetest_valuetest_valuetest_valuetest_value"
+        self.msg_prop_value_bytes = b"test_valuetest_valuetest_valuetest_valuetest_value"
+        self.msg_prop_value_bool = True
+        self.msg_prop_value_int8 = -127
+        self.msg_prop_value_int16 = -32768
+        self.msg_prop_value_int32 = -2147483647
+        self.msg_prop_value_int64 = -9223372036854775808
+        self.msg_prop_value_float32 = 1.1754943508222875e-38
+        self.msg_prop_value_float64 = 2.2250738585072014e-308
+
+
 
         # max length of queue names is 48 characters
-        self.queue_name = "{prefix}.MSG.PROP.QUEUE".format(prefix=config.MQ.QUEUE.PREFIX)
+        self.queue_name = "{prefix}MSG.PROP.QUEUE".format(prefix=config.MQ.QUEUE.PREFIX)
         self.queue_manager = config.MQ.QM.NAME
         self.channel = config.MQ.QM.CHANNEL
         self.host = config.MQ.QM.HOST
@@ -35,7 +46,7 @@ class TestMP(unittest.TestCase):
         """
         if self.queue_name:
             self.delete_queue(self.queue_name)
-        self.qmgr.disconnect()        
+        self.qmgr.disconnect()
 
     def create_queue(self, queue_name):
         queue_type = pymqi.CMQC.MQQT_LOCAL
@@ -43,30 +54,62 @@ class TestMP(unittest.TestCase):
 
         args = {pymqi.CMQC.MQCA_Q_NAME: utils.py3str2bytes(queue_name),
                 pymqi.CMQC.MQIA_Q_TYPE: queue_type,
-                pymqi.CMQC.MQIA_MAX_Q_DEPTH: max_depth, 
+                pymqi.CMQC.MQIA_MAX_Q_DEPTH: max_depth,
                 pymqi.CMQCFC.MQIACF_REPLACE: pymqi.CMQCFC.MQRP_YES}
         pcf = pymqi.PCFExecute(self.qmgr)
         pcf.MQCMD_CREATE_Q(args)
         pcf.disconnect
 
     def delete_queue(self, queue_name):
-        
+
         pcf = pymqi.PCFExecute(self.qmgr)
         args = {pymqi.CMQC.MQCA_Q_NAME: utils.py3str2bytes(queue_name),
                 pymqi.CMQCFC.MQIACF_PURGE: pymqi.CMQCFC.MQPO_YES}
         pcf.MQCMD_DELETE_Q(args)
-    
-    def workWithProp(self):
+
+    def get_value_length(self, property_type, property_value = ''):
+        value_length = 0
+        if property_type == pymqi.CMQC.MQTYPE_BOOLEAN:
+            value_length = 4
+        elif property_type == pymqi.CMQC.MQTYPE_BYTE_STRING:
+            value_length=len(property_value)
+        elif property_type == pymqi.CMQC.MQTYPE_INT8:
+            value_length = 1
+        elif property_type == pymqi.CMQC.MQTYPE_INT16:
+            value_length = 2
+        elif property_type == pymqi.CMQC.MQTYPE_INT32:
+            value_length = 4
+        elif property_type == pymqi.CMQC.MQTYPE_INT64:
+            value_length = 8
+        elif property_type == pymqi.CMQC.MQTYPE_FLOAT32:
+            value_length = 4
+        elif property_type == pymqi.CMQC.MQTYPE_FLOAT64:
+            value_length = 8
+        elif property_type == pymqi.CMQC.MQTYPE_STRING:
+            value_length=len(property_value)
+        elif property_type == pymqi.CMQC.MQTYPE_NULL:
+            value_length == 0
+
+        return value_length
+
+    def work_with_property(self, property_value, property_type):
         messageHandle_get = None
+        queue_get = None
+        queue_put = None
         try:
+
+            value_length = self.get_value_length(property_type, property_value)
+
             cmho_put = pymqi.CMHO()
             messageHandle_put = pymqi.MessageHandle(self.qmgr, cmho_put)
-            messageHandle_put.properties.set(self.msg_prop_name, self.msg_prop_value)
-            
-            pmo = pymqi.PMO()
+            messageHandle_put.properties.set(self.msg_prop_name, property_value,
+                                            value_length=value_length,
+                                            property_type=property_type)
+
+            pmo = pymqi.PMO(Version=pymqi.CMQC.MQPMO_CURRENT_VERSION)
             pmo.OriginalMsgHandle = messageHandle_put.msg_handle
 
-            md_put = pymqi.MD()
+            md_put = pymqi.MD(Version=pymqi.CMQC.MQMD_CURRENT_VERSION)
 
             queue_put = pymqi.Queue(self.qmgr, self.queue_name, pymqi.CMQC.MQOO_OUTPUT)
             queue_put.put(b'', md_put, pmo)
@@ -74,11 +117,11 @@ class TestMP(unittest.TestCase):
             queue_put.close()
 
 
-            gmo = pymqi.GMO()
-            gmo.Options = pymqi.CMQC.MQGMO_NO_WAIT | pymqi.CMQC.MQGMO_PROPERTIES_IN_HANDLE 
+            gmo = pymqi.GMO(Version=pymqi.CMQC.MQGMO_CURRENT_VERSION)
+            gmo.Options = pymqi.CMQC.MQGMO_NO_WAIT | pymqi.CMQC.MQGMO_PROPERTIES_IN_HANDLE
             gmo.MatchOptions = pymqi.CMQC.MQMO_MATCH_MSG_ID
 
-            cmho_get = pymqi.CMHO()
+            cmho_get = pymqi.CMHO(Version=pymqi.CMQC.MQCMHO_CURRENT_VERSION)
             messageHandle_get = pymqi.MessageHandle(self.qmgr, cmho_get)
             gmo.MsgHandle = messageHandle_get.msg_handle
             md_get = pymqi.MD()
@@ -90,12 +133,25 @@ class TestMP(unittest.TestCase):
             if queue_put:
                 if queue_put.get_handle():
                     queue_put.close()
-            
+
             if queue_get:
                 if queue_get.get_handle():
                     queue_get.close()
 
-        return messageHandle_get        
+        return messageHandle_get
+
+    def get_property_value(self, messageHandle_get, property_type, value_length = None, property_modify = False):
+        if not value_length:
+            value_length = self.get_value_length(property_type)
+        if property_modify:
+            property_name = self.msg_prop_name*2
+        else:
+            property_name = self.msg_prop_name
+
+        return messageHandle_get.properties.get(property_name, property_type = property_type, max_value_length = value_length)
+
+
+
 
 ############################################################################
 #
@@ -104,19 +160,85 @@ class TestMP(unittest.TestCase):
 ############################################################################
 
     def test_message_properties_short(self):
-        messageHandle_get = self.workWithProp()
+        messageHandle_get = self.work_with_property(self.msg_prop_value_bytes, pymqi.CMQC.MQTYPE_BYTE_STRING)
 
         try:
-            messageHandle_get.properties.get(self.msg_prop_name, max_value_length=len(self.msg_prop_value)//2)
+            messageHandle_get.properties.get(self.msg_prop_name, max_value_length=len(self.msg_prop_value_bytes)//2)
         except pymqi.MQMIError as e:
             self.assertEqual(e.reason, pymqi.CMQC.MQRC_PROPERTY_VALUE_TOO_BIG, e)
 
-    def test_message_properties_full(self):
-        messageHandle_get = self.workWithProp()
+    def test_message_properties_byte(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_bytes, pymqi.CMQC.MQTYPE_BYTE_STRING)
 
-        value = messageHandle_get.properties.get(self.msg_prop_name, max_value_length=len(self.msg_prop_value))
-        
-        self.assertEqual(self.msg_prop_value, value)
+        value = messageHandle_get.properties.get(self.msg_prop_name, max_value_length=len(self.msg_prop_value_bytes))
+
+        self.assertEqual(self.msg_prop_value_bytes, value)
+
+    def test_message_properties_str(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_str, pymqi.CMQC.MQTYPE_STRING)
+
+        value = messageHandle_get.properties.get(self.msg_prop_name, max_value_length=len(self.msg_prop_value_str))
+
+        self.assertEqual(self.msg_prop_value_str, value)
+
+    def test_message_properties_bool(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_bool, pymqi.CMQC.MQTYPE_BOOLEAN)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_BOOLEAN)
+
+        self.assertEqual(self.msg_prop_value_bool, value)
+
+    def test_message_properties_int8(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_int8, pymqi.CMQC.MQTYPE_INT8)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_INT8)
+
+        self.assertEqual(self.msg_prop_value_int8, value)
+
+    def test_message_properties_int16(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_int16, pymqi.CMQC.MQTYPE_INT16)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_INT16)
+
+        self.assertEqual(self.msg_prop_value_int16, value)
+
+    def test_message_properties_int32(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_int32, pymqi.CMQC.MQTYPE_INT32)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_INT32)
+
+        self.assertEqual(self.msg_prop_value_int32, value)
+
+
+    def test_message_properties_int64(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_int64, pymqi.CMQC.MQTYPE_INT64)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_INT64)
+
+        self.assertEqual(self.msg_prop_value_int64, value)
+
+    def test_message_properties_float32(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_float32, pymqi.CMQC.MQTYPE_FLOAT32)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_FLOAT32)
+
+        self.assertEqual(self.msg_prop_value_float32, value)
+
+    def test_message_properties_float64(self):
+        messageHandle_get = self.work_with_property(self.msg_prop_value_float64, pymqi.CMQC.MQTYPE_FLOAT64)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_FLOAT64)
+
+        self.assertEqual(self.msg_prop_value_float64, value)
+
+    def test_message_properties_null(self):
+        messageHandle_get = self.work_with_property(None, pymqi.CMQC.MQTYPE_NULL)
+        value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_NULL)
+
+        self.assertEqual(None, value)
+
+    def test_message_properties_nonexist(self):
+        messageHandle_get = self.work_with_property(None, pymqi.CMQC.MQTYPE_NULL)
+        try:
+            value = self.get_property_value(messageHandle_get, pymqi.CMQC.MQTYPE_NULL, property_modify = True)
+
+        except pymqi.MQMIError as e:
+            self.assertEqual(e.reason, pymqi.CMQC.MQRC_PROPERTY_NOT_AVAILABLE, e)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I modified pimqe (and other) file for adding support of non-string properties values.
Code tested on Ubuntu 18.04 with python 2.7 and 3.7 and Windows 2016 with python 3.7
I hope it close #104 and #112 issues also.