### PR TITLE
Enable ccdt usage with user, password for python 2.x

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -1425,9 +1425,9 @@ class QueueManager(object):
         if 'cd' in kw:
             ocd = kw['cd']
         if 'sco' in kw:
-            rv = pymqe.MQCONNX(name, options, ocd.pack(), user_password, kw['sco'].pack())
+            rv = pymqe.MQCONNX(name, options, ocd.pack() if ocd else None, user_password, kw['sco'].pack())
         else:
-            rv = pymqe.MQCONNX(name, options, ocd.pack(), user_password, osco.pack())
+            rv = pymqe.MQCONNX(name, options, ocd.pack() if ocd else None, user_password, osco.pack())
         if rv[1]:
             raise MQMIError(rv[1], rv[2])
         self.__handle = rv[0]

--- a/code/pymqi/pymqe.c
+++ b/code/pymqi/pymqe.c
@@ -332,7 +332,7 @@ static PyObject * pymqe_MQCONNX(PyObject *self, PyObject *args) {
   char *sco = NULL;
   Py_ssize_t sco_len = 0;
 #if PY_MAJOR_VERSION==2
-  if (!PyArg_ParseTuple(args, "sls#O|s#", &name, &options, &mqcd, &mqcd_buf_len, &user_password, &sco, &sco_len)) {
+  if (!PyArg_ParseTuple(args, "slz#O|s#", &name, &options, &mqcd, &mqcd_buf_len, &user_password, &sco, &sco_len)) {
 #else
   if (!PyArg_ParseTuple(args, "yly#O|y#", &name, &options, &mqcd, &mqcd_buf_len, &user_password, &sco, &sco_len)) {
 #endif
@@ -351,7 +351,7 @@ static PyObject * pymqe_MQCONNX(PyObject *self, PyObject *args) {
   }
 #endif
 
-  if (checkArgSize(mqcd_buf_len, PYMQI_MQCD_SIZEOF, "MQCD")) {
+  if (mqcd && checkArgSize(mqcd_buf_len, PYMQI_MQCD_SIZEOF, "MQCD")) {
     return NULL;
   }
 
@@ -384,7 +384,9 @@ static PyObject * pymqe_MQCONNX(PyObject *self, PyObject *args) {
     }
   }
 
-  cno.ClientConnPtr = (MQCD *)mqcd;
+  if(mqcd) {
+    cno.ClientConnPtr = (MQCD *)mqcd;
+  }
   cno.Options = (MQLONG)options;
 
   Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
We ( @chughts ) made these changes and tested them locally so we could use CCDT as well as pass in the user and password values. To be able to use CCDT the cno.ClientConnPtr should not be set.

Change in pymqe.c:

Line 335 format string (for python 2.x but not for 3) "sls#O|s#" -> "slz#O|s#", to allow None value for the cd. We don't know what the equivalent for python 3 would be so we didn't change that.

Not sure if 346 should be modified too ->   if (!PyArg_ParseTuple(args, "sls#", &name, &options, &mqcd, &mqcd_buf_len)) {


In 354 we modified the if clause to add a check on mqcd
```python
  if (mqcd && checkArgSize(mqcd_buf_len, PYMQI_MQCD_SIZEOF, "MQCD")) {
    return NULL;
  }
```

We also added an if around 387
```python
  if(mqcd) {
    cno.ClientConnPtr = (MQCD *)mqcd;
  }
  cno.Options = (MQLONG)options;
```
In __init__.py, the change is from line 1427;


```python
        if 'sco' in kw:
            rv = pymqe.MQCONNX(name, options, ocd.pack() if ocd else None, user_password, kw['sco'].pack())
        else:
            rv = pymqe.MQCONNX(name, options, ocd.pack()if ocd else None, user_password, osco.pack()
```

Usage:
```python
        qm = pymqi.QueueManager(None)

        qm.connect_with_options(queue_manager,
                                  user=appuser,
                                  password=apppassword,
                                  opts=options, cd=None, sco=sco)
```