### PR TITLE
Unpack headers with versions prior to current

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -271,6 +271,11 @@ class MQOpts(object):
 
         check_not_py3str(buff)  # Python 3 bytes check
 
+        # Increase buff length to the current MQOpts structure size
+        diff_length = self.get_length() - len(buff)
+        if diff_length > 0:
+            buff += b'\x00' * diff_length
+
         # Unpack returns a tuple of the unpacked data, in the same
         # order (I hope!) as in the ctor's list arg.
         r = struct.unpack(self.__format, buff)


### PR DESCRIPTION
Sometime there is need to unpack headers, that has version less than *_CURRENT_VERSION. In this case buffer is less than MQOpts structure length and we need to increase it to current size.