### PR TITLE
Updating link to support documentation

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -2289,8 +2289,8 @@ class FilterOperator(object):
             priv_filter_class = StringFilter
         else:
             msg = 'selector [%s] is of an unsupported type (neither integer ' \
-                'nor a string attribute). Send details to http://packages.' \
-                'python.org/pymqi/support-consulting-contact.html'
+                'nor a string attribute). Please see' \
+                'https://dsuch.github.io/pymqi/support.html'
             raise Error(msg % self.pub_filter.selector)
 
         # Do we support the operator?


### PR DESCRIPTION
The old link seems to be returning a 301 response code.  

https://dsuch.github.io/pymqi/support.html seems like a better place to direct users.