### PR TITLE
support for zos

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -2663,9 +2663,14 @@ class _Method:
         command_queue.put(message, put_md, put_opts)
         command_queue.close()
 
+        gmo_options = CMQC.MQGMO_NO_SYNCPOINT + CMQC.MQGMO_FAIL_IF_QUIESCING + \
+                      CMQC.MQGMO_WAIT
+
+        if self.__pcf.convert:
+            gmo_options = gmo_options + CMQC.MQGMO_CONVERT
+
         get_opts = GMO(
-            Options=CMQC.MQGMO_NO_SYNCPOINT + CMQC.MQGMO_FAIL_IF_QUIESCING +
-            CMQC.MQGMO_WAIT + CMQC.MQGMO_CONVERT,
+            Options=gmo_options,
             Version=CMQC.MQGMO_VERSION_2,
             MatchOptions=CMQC.MQMO_MATCH_CORREL_ID,
             WaitInterval=self.__pcf.response_wait_interval)
@@ -2710,7 +2715,8 @@ class PCFExecute(QueueManager):
                  model_queue_name=b'SYSTEM.DEFAULT.MODEL.QUEUE',
                  dynamic_queue_name=b'PYMQPCF.*',
                  command_queue_name=b'',
-                 response_wait_interval=100):
+                 response_wait_interval=100,
+                 convert=False):
         # type: (Any, bool, bytes, bytes, bytes) -> None
         """PCFExecute(name = '')
 
@@ -2719,6 +2725,7 @@ class PCFExecute(QueueManager):
         used for the connection, otherwise a new connection is made """
 
         self.response_wait_interval = response_wait_interval
+        self.convert = convert
 
         if command_queue_name:
             self._command_queue_name = command_queue_name

--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -2591,13 +2591,9 @@ class _Method:
         else:
             args_dict, filters = {}, []
 
-        if filters:
-            cfh_version = CMQCFC.MQCFH_VERSION_3
-        else:
-            cfh_version = CMQCFC.MQCFH_VERSION_1
-
-        mqcfh = CFH(Version=cfh_version,
+        mqcfh = CFH(Version=CMQCFC.MQCFH_VERSION_3,
                     Command=CMQCFC.__dict__[self.__name],
+                    Type=CMQCFC.MQCFT_COMMAND_XR,
                     ParameterCount=len(args_dict) + len(filters))
         message = mqcfh.pack()
 
@@ -2669,7 +2665,7 @@ class _Method:
 
         get_opts = GMO(
             Options=CMQC.MQGMO_NO_SYNCPOINT + CMQC.MQGMO_FAIL_IF_QUIESCING +
-            CMQC.MQGMO_WAIT,
+            CMQC.MQGMO_WAIT + CMQC.MQGMO_CONVERT,
             Version=CMQC.MQGMO_VERSION_2,
             MatchOptions=CMQC.MQMO_MATCH_CORREL_ID,
             WaitInterval=self.__pcf.response_wait_interval)


### PR DESCRIPTION
Hi @SeyfSV, 

Thanks for the raw PCF code.  This PR has changes to support PCF on z/OS platform.  Can you please review?  These changes are valid for non z/OS queue managers also and tested successfully.

1. Use MQCFH_VERSION_3 for CFH header
2. Add Type=MQCFT_COMMAND_XR to support z/OS
3. Add MQGMO_CONVERT to get_opts when reading PCF response