### PR TITLE
Make `PCFExecute.unpack()` return full header

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -2964,7 +2964,7 @@ class PCFExecute(QueueManager):
             else:
                 res[parameter.Parameter] = value
 
-        return res, mqcfh.Control
+        return res, mqcfh
 
 
 class ByteString(object):

--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -2733,11 +2733,11 @@ class _Method:
         ress = []
         while True:
             message = self.__pcf.reply_queue.get(None, get_md, get_opts)
-            res, control = self.__pcf.unpack(message)
+            res, mqcfh_response = self.__pcf.unpack(message)
 
             ress.append(res)
 
-            if control == CMQCFC.MQCFC_LAST:
+            if mqcfh_response.Control == CMQCFC.MQCFC_LAST:
                 break
 
         return ress


### PR DESCRIPTION
The header is also part of things we unpack, we should return it too. The data in the header can be as useful as the data in the message itself.

Use case: decide how to process the unpacked message depending on the header information (e.g. header.Command).

This is a **breaking change** since the `PCFExecute.unpack()` method is already released in `v1.11.1`, for people relying on `mqcfh.Control` previously returned.

Open questions:

- Any suggestion about possible way to avoid the breaking change but still get similar feature ?

cc @SeyfSV 