### PR TITLE
Add prerequisite for Windows

### DIFF
--- a/code/README
+++ b/code/README
@@ -63,7 +63,8 @@ Installation
   it is a free library offered by IBM on top of which higher-level ones, such as PyMQI, can connect to queue managers.
   IBM MQ clients can be downloaded from IBM's website.
  
-* Prerequisite for Windows: Microsoft Visual C++ 14.0. Get it with "Build Tools for Visual Studio": https://visualstudio.microsoft.com/downloads/
+* Prerequisite for Windows: Microsoft Visual C++ compiler.
+  Each Python version uses a specific compiler version. So, you need to install the compiler version that corresponds to your Python version : https://wiki.python.org/moin/WindowsCompilers
 
 * Now you can use pip to install PyMQI itself:
 

--- a/code/README
+++ b/code/README
@@ -62,6 +62,8 @@ Installation
 * As a prerequisite, you first need to install an IBM MQ client in the system that PyMQI is about to be installed;
   it is a free library offered by IBM on top of which higher-level ones, such as PyMQI, can connect to queue managers.
   IBM MQ clients can be downloaded from IBM's website.
+ 
+* Prerequisite for Windows: Microsoft Visual C++ 14.0. Get it with "Build Tools for Visual Studio": https://visualstudio.microsoft.com/downloads/
 
 * Now you can use pip to install PyMQI itself:
 


### PR DESCRIPTION
pip returns an error message if it does not find the build tools