### PR TITLE
Increase Cypher limit to 38

### DIFF
--- a/code/pymqi/__init__.py
+++ b/code/pymqi/__init__.py
@@ -931,7 +931,7 @@ class CD(MQOpts):
             ['MCASecurityId', b'', '40s'],
             ['RemoteSecurityId', b'', '40s'],
             # Version 6
-            ['SSLCipherSpec', b'', '32s'],
+            ['SSLCipherSpec', b'', '38s'],
             ['SSLPeerNamePtr', 0, 'P'],
             ['SSLPeerNameLength', py23long(0), MQLONG_TYPE],
             ['SSLClientAuth', py23long(0), MQLONG_TYPE],


### PR DESCRIPTION
Currently, i am trying to connect with SSL using the cipher: SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256
The problem is because of the limit of 32 the cipher that is sent is: CommentInsert2(SSL_ECDHE_RSA_WITH_AES_128_GCM_S) limited to 32.
Can we increase this field, please?